### PR TITLE
Updating for C99+ stdint types.

### DIFF
--- a/core/c/imio.c
+++ b/core/c/imio.c
@@ -305,8 +305,8 @@ IMAGE *read_image(char *fn)
   IMAGE *im;
   TIFF *tiffp;
   unsigned long int nbyte=0, bread=0;
-  uint32 *s_o_t, rps;
-  uint16 spp=1, pc=1;
+  uint32_t *s_o_t, rps;
+  uint16_t spp=1, pc=1;
   long int fsot; /* offset to 1st pixel */
   unsigned short int *tred, *tgreen, *tblue;
   unsigned short int *red, *green, *blue;
@@ -419,9 +419,9 @@ IMAGE *read_image(char *fn)
     TIFFGetField(tiffp, TIFFTAG_STRIPOFFSETS, &s_o_t);
     fsot = (long)*s_o_t;
     TIFFGetField(tiffp, TIFFTAG_BITSPERSAMPLE, &bitpp);
-    red = (uint16 *)malloc(1<<bitpp*sizeof(uint16));
-    green = (uint16 *)malloc(1<<bitpp*sizeof(uint16));
-    blue = (uint16 *)malloc(1<<bitpp*sizeof(uint16));
+    red = (uint16_t *)malloc(1<<bitpp*sizeof(uint16_t));
+    green = (uint16_t *)malloc(1<<bitpp*sizeof(uint16_t));
+    blue = (uint16_t *)malloc(1<<bitpp*sizeof(uint16_t));
     TIFFGetField(tiffp, TIFFTAG_PHOTOMETRIC, &pmi);
     if (TIFFGetField(tiffp, TIFFTAG_COLORMAP, &tred, &tgreen, &tblue) != 1)
       cm=0;
@@ -1219,8 +1219,8 @@ IMAGE *read_image_to_type(char *fn, int data_type)
   IMAGE *im, *lim;
   TIFF *tiffp;
   unsigned long int nbyte=0, bread=0;
-  uint32 rps;
-  uint16 spp=1, pc=1;
+  uint32_t rps;
+  uint16_t spp=1, pc=1;
   tstrip_t nstrip, strip;
   long int i;
   int nx, ny;

--- a/core/c/imio2.c
+++ b/core/c/imio2.c
@@ -23,6 +23,7 @@ along with miallib.  If not, see <https://www.gnu.org/licenses/>.
 #include <string.h>
 #include <time.h>
 #include <unistd.h>  /* for gethostname */
+#include <stdint.h>
 #ifndef UNIX
 // #include "bytesex.h" /* <endian.h> only for linux ... */
 #include  <endian.h>
@@ -117,8 +118,8 @@ ERROR_TYPE tiffinfo(char *fn, char *field, float *val)
 {
   TIFF *tiffp;
   GTIF *gtif=NULL;
-  uint32 a_uint32;
-  uint16  a_uint16;
+  uint32_t a_uint32;
+  uint16_t  a_uint16;
   geocode_t gkey_val;
 /*   if ((tiffp = TIFFOpen(fn, "rc")) == NULL){ */
 /*     (void)sprintf(buf,"ERROR in tiffinfo(): invalid TIFF file name \"%s\" \n", fn); errputstr(buf); */
@@ -220,8 +221,8 @@ IMAGE *tiffinfoJIP(char *fn)
   GTIF *gtif=NULL;
   IMAGE *im=NULL;
   UINT32 *pim;
-  uint32 a_uint32;
-  uint16  a_uint16;
+  uint32_t a_uint32;
+  uint16_t  a_uint16;
   geocode_t gkey_val;
 
   /* Open TIFF descriptor to read GeoTIFF tags */
@@ -716,8 +717,8 @@ IMAGE *readTiffSubset(char *fn, int x, int y, unsigned szx, unsigned szy)
     TIFF *tif;
     UCHAR *pim = NULL, *ptmp = NULL;
     unsigned long stripCount;
-    uint16 bps, spp, rps, comp, sf, bpp;
-    uint32 nx, ny;
+    uint16_t bps, spp, rps, comp, sf, bpp;
+    uint32_t nx, ny;
     int data_type;
     IMAGE *im=NULL;
 


### PR DESCRIPTION
(u)int16/32 are deprecated in C99+ and replaced by stdint.h *_t types. This fixes a deprecation warning with any modern GCC versions.