### PR TITLE
Fix FBTFS with GCC 15.

### DIFF
--- a/core/c/convolve.c
+++ b/core/c/convolve.c
@@ -1014,7 +1014,7 @@ IMAGE *mean2dse(IMAGE *im, IMAGE *imse, int ox, int oy)
   }
   return NULL;
 }
-extern ERROR_TYPE write_tiff();
+extern ERROR_TYPE write_tiff(IMAGE *im, char *fn);
 
 
 #include "uc_def.h"

--- a/core/c/dcluster.c
+++ b/core/c/dcluster.c
@@ -26,7 +26,7 @@ along with miallib.  If not, see <https://www.gnu.org/licenses/>.
 
 
 
-extern ERROR_TYPE us_plotline();
+extern ERROR_TYPE us_plotline(IMAGE *im, int x1, int y1, int x2, int y2, int val);
 
 
 ERROR_TYPE agglo_cluster(int *x, int *y, int *pn, double maxdst)

--- a/core/c/miallib.h
+++ b/core/c/miallib.h
@@ -355,8 +355,8 @@ extern void stdputstr(char *); /* print a message to the standard output */
 extern void errputstr(char *); /* print a message to the standard error  */
 #else
 static char buf[1024];       /* used by sprintf() and stdputstr() */
-extern void stdputstr(); /* print a message to the standard output */
-extern void errputstr(); /* print a message to the standard error  */
+extern void stdputstr(char *); /* print a message to the standard output */
+extern void errputstr(char *); /* print a message to the standard error  */
 #endif /* #if (defined(XLISP)) */
 #endif
 

--- a/core/c/setreg.c
+++ b/core/c/setreg.c
@@ -34,9 +34,9 @@ along with miallib.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 extern int cluster();
-extern ERROR_TYPE agglo_cluster();
-extern ERROR_TYPE nearest_cluster();
-extern ERROR_TYPE knearest_cluster();
+extern ERROR_TYPE agglo_cluster(int *x, int *y, int *pn, double maxdst);
+extern ERROR_TYPE nearest_cluster(IMAGE *im, int *x, int *y, int *pn, double maxdst);
+extern ERROR_TYPE knearest_cluster(IMAGE *im, int *x, int *y, int *pn, int k, double maxdst);
 
 #define set_mean_type(TYPE1, TYPE2, i1, i2) \
 {\
@@ -162,7 +162,7 @@ extern ERROR_TYPE knearest_cluster();
   }  \
 }
 
-extern IMBLOB *create_blob();
+extern IMBLOB *create_blob(LBL_TYPE n);
 
 
 

--- a/core/c/uswilk.c
+++ b/core/c/uswilk.c
@@ -1505,7 +1505,7 @@ int MAXROIVAL  =  65534;   /* pixels outside ROI should be at 255,
 int OUTROI     = 65535;
 
 
-extern ERROR_TYPE set_seq_shift();
+extern ERROR_TYPE set_seq_shift(long int , long int , long int , long int , long int *);
 
 void GreyAttributeClosingROI ( double lambdaVal,    /* threshold on attribute */
                             int width,        /* image width  */


### PR DESCRIPTION
As reported in [Debian Bug #1096871](https://bugs.debian.org/1096871), jeolib-miallib fails to build with GCC 15:
```
/build/reproducible-path/jeolib-miallib-1.1.6/core/c/classification.c:1571:61: error: too many arguments to function ‘errputstr’; expected 0, have 1
 1571 |     (void)sprintf(buf,"clmaxlike(): invalid pixel type\n"); errputstr(buf);
      |                                                             ^~~~~~~~~ ~~~
/build/reproducible-path/jeolib-miallib-1.1.6/core/c/miallib.h:359:13: note: declared here
  359 | extern void errputstr(); /* print a message to the standard error  */
      |             ^~~~~~~~~
```
See also: https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters