### PR TITLE
Use ${CMAKE_INSTALL_LIBDIR} from GNUInstallDirs instead of hardcoding lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ add_definitions(-DSHAPE_DLL)
 INSTALL(TARGETS ${MIALLIB_LIB_NAME}
   EXPORT "${MIALLIB_LIB_NAME}"
   COMPONENT libraries
-  LIBRARY DESTINATION lib)
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 INSTALL(FILES ${MIALLIB_H} DESTINATION include/miallib/)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/miallib-config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/miallib-config-version.cmake
@@ -405,5 +405,5 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/miallib-config.cmake
   COMPONENT headers
   )
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/miallib.pc
-        DESTINATION lib/pkgconfig
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/cmake.pc.in
+++ b/cmake.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@/bin
-libdir=@CMAKE_INSTALL_PREFIX@/lib
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
 includedir=@CMAKE_INSTALL_PREFIX@/include
 
 Name: miallib


### PR DESCRIPTION
The generated CMake and pkg-config files were incorrect for the Debian package which uses the multiarch path for libraries.

The variable was not consistently used in CMakeLists.txt, only the CMake files where correctly installed in the multiarch path.